### PR TITLE
Fix authentication middleware and sanitize folder names

### DIFF
--- a/backend/src/middleware/authMiddleware.ts
+++ b/backend/src/middleware/authMiddleware.ts
@@ -2,7 +2,7 @@ import jwt from 'jsonwebtoken';
 
 const JWT_SECRET = process.env.JWT_SECRET!;
 
-export default function authenticateToken (req: any, res: any) {
+export default function authenticateToken(req: any, res: any, next: any) {
   const authHeader = req.headers['authorization'];
   const token = authHeader?.split(' ')[1]; // "Bearer <token>"
 
@@ -12,7 +12,8 @@ export default function authenticateToken (req: any, res: any) {
 
   try {
     const decoded = jwt.verify(token, JWT_SECRET);
-    return res.status(200).json({ success: "You can now use the app!" })
+    req.user = decoded;
+    return next();
   } catch (err) {
     return res.status(403).json({ error: 'Invalid or expired token' });
   }

--- a/backend/src/routes/folderRoutes.ts
+++ b/backend/src/routes/folderRoutes.ts
@@ -7,7 +7,7 @@ const prisma = new PrismaClient();
 
 router.post('/create', async (req, res) => {
     //receive variables to create folder
-    const {name, createdBy} = req.body;
+    const { name, createdBy } = req.body;
 
     const folderName = sanitize(name);
 
@@ -15,7 +15,7 @@ router.post('/create', async (req, res) => {
     try {
         await prisma.folder.create({
             data: {
-                name,
+                name: folderName,
                 createdBy,
             }
         });


### PR DESCRIPTION
## Summary
- ensure token middleware actually verifies and allows request
- sanitize folder names on creation

## Testing
- `npm test` (fails: Error: no test specified)
- `npm test` in `frontend` (fails to run - missing script)

------
https://chatgpt.com/codex/tasks/task_e_683f77e908f0832687cd42de8b428e12