### PR TITLE
Adjust created at column chevron

### DIFF
--- a/frontend/src/components/Table.tsx
+++ b/frontend/src/components/Table.tsx
@@ -238,7 +238,9 @@ export default function Table({ files, folders, sortDirection, sortKey, onUpdate
                         <th className="pl-6 pr-1 py-2 text-left cursor-pointer" onClick={() => onHeaderClick("createdAt")}>
                             <div className="flex flex-row items-center gap-1">
                             Created at
+                            {sortKey === "createdAt" && (
                                 <FontAwesomeIcon icon={sortDirection === "asc" ? faCaretUp : faCaretDown} />
+                            )}
                             </div>
                         </th>
                         <th className="pl-6 pr-1 py-2 text-left cursor-pointer" onClick={() => onHeaderClick("type")}>


### PR DESCRIPTION
Conditionally render 'Created at' column chevron to disappear when other columns are sorted.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents%3Fid=bc-ef9cfa84-7942-428e-b2e9-5d928ba0be69) · [Cursor](https://cursor.com/background-agent%3FbcId=bc-ef9cfa84-7942-428e-b2e9-5d928ba0be69)